### PR TITLE
add property "main" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mocha": "^2.2.4",
     "requirejs": "^2.1.17"
   },
+  "main": "dist/router.min.js",
   "scripts": {
     "main": "dist/router.min.js",
     "test": "./node_modules/karma/bin/karma start"


### PR DESCRIPTION

Hi ramiel.

Thanks for great library. 

I tried to use route.js with browserify but it fails when compiling.
I found that `package.json` does not have `main` property , so i added and it worked.

thanks.


FYI

```js
// code I tried
var Router = require("router.js"); 
```

and i got error messages below.

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: Cannot find module 'router.js' from '/Users/rocky/nextremer/piculetly/vendor'
    at /Users/rocky/nextremer/piculetly/node_modules/browserify/node_modules/resolve/lib/async.js:46:17
    at process (/Users/rocky/nextremer/piculetly/node_modules/browserify/node_modules/resolve/lib/async.js:173:43)
    at ondir (/Users/rocky/nextremer/piculetly/node_modules/browserify/node_modules/resolve/lib/async.js:188:17)
    at load (/Users/rocky/nextremer/piculetly/node_modules/browserify/node_modules/resolve/lib/async.js:69:43)
    at onex (/Users/rocky/nextremer/piculetly/node_modules/browserify/node_modules/resolve/lib/async.js:92:31)
    at /Users/rocky/nextremer/piculetly/node_modules/browserify/node_modules/resolve/lib/async.js:22:47
    at Object.oncomplete (fs.js:107:15)
```