### PR TITLE
Fix/license format

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "hashtag",
     "location"
   ],
-  "license": "GPL-2",
+  "license": "GPL-2.0",
   "ignore": [
     "doc",
     "examples",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   "scripts": {
     "test": "./node_modules/karma/bin/karma start"
   },
-  "license": "GPL2",
+  "license": "GPL-2.0",
   "engine": "node >= 0.8.0"
 }


### PR DESCRIPTION
The [package.json specification][1] and [bower.json specification][2] recommend using a SPDX license identifier. The correct short identifier is [GPL-2.0][3]. This PR changes the license field in `package.json` and `bower.json`.
    
[1]: https://docs.npmjs.com/files/package.json#license
[2]: https://github.com/bower/bower.json-spec#license
[3]: https://spdx.org/licenses/GPL-2.0.html
